### PR TITLE
SetPrice Function Error Handling

### DIFF
--- a/SND/MarketBotty/MarketBotty.lua
+++ b/SND/MarketBotty/MarketBotty.lua
@@ -346,7 +346,9 @@ end
 
 function SetPrice(price)
   debug("Setting price to: "..price)
-  yield("/callback ItemSearchResult true -1")
+  if IsAddonVisible("ItemSearchResult") then
+    yield("/callback ItemSearchResult true -1")
+  end
   yield("/callback RetainerSell true 2 "..price)
   yield("/callback RetainerSell true 0")
   CloseSales()


### PR DESCRIPTION
When `SetPrice` is called by `RepeatItem`, the addon `ItemSearchResult` does not exist as it was never opened. This causes an error with snd's implementation of `/callback` and the new error handling added to it, killing the peon.

This PR adds a simple `if/then` to check if the addon exists before sending `/callback`.